### PR TITLE
fix: return the correct value from isQueueEmpty()

### DIFF
--- a/src/BackgroundProcess/Adapter/Out/Wp/WpBackgroundJobQueue.php
+++ b/src/BackgroundProcess/Adapter/Out/Wp/WpBackgroundJobQueue.php
@@ -317,7 +317,7 @@ abstract class WpBackgroundJobQueue extends WpAjaxHandler implements BackgroundJ
     {
         try
         {
-            return $this->batchRepository->batchItemsExist();
+            return !$this->batchRepository->batchItemsExist();
         }
         catch (RepositoryException $exception)
         {


### PR DESCRIPTION
This was fixed before, but the changes must have been lost during merge or something.

The background process will now correctly run when there are items in the queue.