### PR TITLE
fix: return value from filter instead of void

### DIFF
--- a/src/BackgroundProcess/Adapter/Out/Wp/WpBackgroundJobQueue.php
+++ b/src/BackgroundProcess/Adapter/Out/Wp/WpBackgroundJobQueue.php
@@ -52,7 +52,7 @@ abstract class WpBackgroundJobQueue extends WpAjaxHandler implements BackgroundJ
             $this->handleCronHealthcheck();
         });
         add_filter('cron_schedules', function($schedules): void {
-            $this->scheduleCronHealthcheck($schedules);
+            return $this->scheduleCronHealthcheck($schedules);
         });
 
         $this->batchRepository = $batchRepository;


### PR DESCRIPTION
Fixes an issue caused by not returning a value from a WP filter.