### PR TITLE
fix: remove void return type for a method that returns mixed

### DIFF
--- a/src/BackgroundProcess/Adapter/Out/Wp/WpBackgroundJobQueue.php
+++ b/src/BackgroundProcess/Adapter/Out/Wp/WpBackgroundJobQueue.php
@@ -51,7 +51,7 @@ abstract class WpBackgroundJobQueue extends WpAjaxHandler implements BackgroundJ
         add_action($this->cron_hook_identifier, function(): void {
             $this->handleCronHealthcheck();
         });
-        add_filter('cron_schedules', function($schedules): void {
+        add_filter('cron_schedules', function($schedules) {
             return $this->scheduleCronHealthcheck($schedules);
         });
 


### PR DESCRIPTION
Although we fixed the `cron_chedules` filter so it returns a value, now, we forgot to change the return type.